### PR TITLE
feat(grafana): provision Prometheus, Tempo, and Loki datasources

### DIFF
--- a/docker/grafana/datasource.yml
+++ b/docker/grafana/datasource.yml
@@ -1,0 +1,47 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    editable: false
+    jsonData:
+      httpMethod: POST
+      exemplarTraceIdDestinations:
+        - name: trace_id
+          datasourceUid: tempo
+  - name: Tempo
+    type: tempo
+    access: proxy
+    orgId: 1
+    url: http://tempo:3200
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false
+    apiVersion: 1
+    uid: tempo
+    jsonData:
+      httpMethod: GET
+      tracesToLogs:
+        datasourceUid: 'loki'
+      nodeGraph:
+        enabled: true
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false
+    apiVersion: 1
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+            matcherRegex: \[.+,(.+?),
+            name: TraceID
+            url: $${__value.raw}


### PR DESCRIPTION
- Added Prometheus datasource with exemplar trace ID integration
- Configured Tempo as default tracing datasource with node graph enabled
- Linked Tempo traces to Loki logs
- Provisioned Loki datasource with derived field mapping to Tempo traces